### PR TITLE
Add a controller to support create content

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,16 +26,20 @@ repositories {
 }
 
 dependencies {
-	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-web")
-	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-	implementation("org.jetbrains.kotlin:kotlin-reflect")
-	implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
-	runtimeOnly("com.h2database:h2")
-	testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
-	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
+    implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.microutils:kotlin-logging-jvm:3.0.5")
+    runtimeOnly("com.h2database:h2")
+    annotationProcessor("org.projectlombok:lombok")
+    testImplementation("org.springframework.boot:spring-boot-starter-test") {
+        exclude(group = "org.mockito", module = "mockito-core")
+    }
+    testImplementation("com.ninja-squad:springmockk:3.0.1")
+    testImplementation("io.kotest:kotest-runner-junit5:5.6.2")
+    testImplementation("io.kotest:kotest-assertions-core:5.6.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 kotlin {

--- a/src/main/kotlin/com/aroundme/content/Content.kt
+++ b/src/main/kotlin/com/aroundme/content/Content.kt
@@ -13,7 +13,7 @@ data class Content (
     val category: String,
     val content: String,
     val media: String,
-    val createdTime: LocalDateTime = LocalDateTime.now()
+    val createdTime: LocalDateTime
 ) {
     fun toReadContentDTO(): ReadContentDTO {
         return ReadContentDTO(
@@ -21,7 +21,7 @@ data class Content (
             content = content,
             category = category,
             media = media,
-            createdTime = LocalDateTime.now()
+            createdTime = createdTime
         )
     }
 }

--- a/src/main/kotlin/com/aroundme/content/ContentController.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentController.kt
@@ -32,7 +32,7 @@ class ContentController (
     }
 
     /**
-     * Create content
+     * Creates a content to cover text and media.
      *
      * @param createContentDTO
      * @return content details

--- a/src/main/kotlin/com/aroundme/content/ContentController.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentController.kt
@@ -3,6 +3,8 @@ package com.aroundme.content
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 /**
@@ -27,5 +29,22 @@ class ContentController (
         return ResponseEntity
             .ok()
             .body(contentList)
+    }
+
+    /**
+     * Create content
+     *
+     * @param createContentDTO
+     * @return content details
+     */
+    @PostMapping("/contents")
+    fun createContent(@RequestBody createContentDTO: CreateContentDTO): ResponseEntity<ReadContentDetailDTO> {
+        // TODO(https://github.com/tein408/aroundme/issues/2): Add session information to the log
+        logger.info("Controller - Creating new content")
+        createContentDTO.validate()
+        val readContentDetailDTO = contentService.createContent(createContentDTO)
+        return ResponseEntity
+            .ok()
+            .body(readContentDetailDTO)
     }
 }

--- a/src/main/kotlin/com/aroundme/content/ContentDTO.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentDTO.kt
@@ -9,3 +9,24 @@ data class ReadContentDTO (
     val media: String,
     val createdTime: LocalDateTime
 )
+
+data class CreateContentDTO (
+    val category: String,
+    val content: String,
+    val media: String,
+    val createdTime: LocalDateTime
+) {
+    fun validate() {
+        if (category.isBlank()) throw IllegalArgumentException("Category must not be blank")
+        if (content.isBlank()) throw IllegalArgumentException("Content must not be blank")
+        if (media.isBlank()) throw IllegalArgumentException("Media must not be blank")
+    }
+}
+
+data class ReadContentDetailDTO(
+    val id: Long?,
+    val category: String,
+    val content: String,
+    val media: String,
+    val createdTime: LocalDateTime
+)

--- a/src/main/kotlin/com/aroundme/content/ContentService.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentService.kt
@@ -3,6 +3,7 @@ package com.aroundme.content
 import mu.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
 
 /**
  * Content service class
@@ -24,5 +25,43 @@ class ContentService (
         logger.info("Service - Getting content list")
         val contentList = contentRepository.findAllBy()
         return contentList.map { it.toReadContentDTO() }
+    }
+
+    /**
+     * Create content
+     *
+     * @param createContentDTO
+     * @return ReadContentDetailDTO
+     */
+    fun createContent(createContentDTO: CreateContentDTO): ReadContentDetailDTO? {
+        // TODO(https://github.com/tein408/aroundme/issues/2): Add session information to the log
+        logger.info("Service - Creating new content: $createContentDTO")
+        val currentTime = LocalDateTime.now()
+
+        validateContent(createContentDTO)
+
+        val content = Content(
+            category = createContentDTO.category,
+            content = createContentDTO.content,
+            media = createContentDTO.media,
+            createdTime = currentTime
+        )
+
+        val savedContent = contentRepository.save(content)
+        logger.info { "Service - Content created successfully: $savedContent" }
+
+        return ReadContentDetailDTO(
+            savedContent.id,
+            createContentDTO.category,
+            createContentDTO.content,
+            createContentDTO.media,
+            currentTime
+        )
+    }
+
+    private fun validateContent(createContentDTO: CreateContentDTO) {
+        if (createContentDTO.content.length > 500) {
+            throw IllegalArgumentException("Content length exceeds the limit of 500 characters")
+        }
     }
 }

--- a/src/main/kotlin/com/aroundme/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/aroundme/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,23 @@
+package com.aroundme.exception
+
+import mu.KotlinLogging
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ExceptionHandler
+
+@ControllerAdvice
+class GlobalExceptionHandler {
+
+    private val logger = KotlinLogging.logger {}
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgumentException(ex: IllegalArgumentException): ResponseEntity<Map<String, String?>> {
+        val errorResponse = mapOf(
+            "error" to "Invalid Request",
+            ("message" to ex.message)
+        )
+        logger.error(ex.message, ex)
+        return ResponseEntity(errorResponse, HttpStatus.BAD_REQUEST)
+    }
+}

--- a/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
@@ -1,13 +1,15 @@
 package com.aroundme.content
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.mockk.every
+import com.ninjasquad.springmockk.MockkBean
 import org.junit.jupiter.api.Test
-import org.mockito.BDDMockito.given
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
-import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.time.LocalDateTime
 
@@ -17,19 +19,36 @@ class ContentControllerTest {
     @Autowired
     private lateinit var mockMvc: MockMvc
 
-    @MockitoBean
+    @MockkBean
     private lateinit var contentService: ContentService
+
+    @Autowired
+    private lateinit var objectMapper: ObjectMapper
 
     @Test
     fun `should return content list`() {
         val contentList = listOf(
-            ReadContentDTO(id = 1L, category = "Software", content = "John Doe's log", media = "/image.jpg", createdTime = LocalDateTime.now()),
-            ReadContentDTO(id = 2L, category = "Network", content = "Jane Smith's announce", media = "/tech.jpg", createdTime = LocalDateTime.now())
+            ReadContentDTO(
+                id = 1L,
+                category = "Software",
+                content = "John Doe's log",
+                media = "/image.jpg",
+                createdTime = LocalDateTime.now()
+            ),
+            ReadContentDTO(
+                id = 2L,
+                category = "Network",
+                content = "Jane Smith's announce",
+                media = "/tech.jpg",
+                createdTime = LocalDateTime.now()
+            )
         )
-        given(contentService.getContentList()).willReturn(contentList)
 
-        mockMvc.perform(get("/contents")
-            .contentType(MediaType.APPLICATION_JSON)
+        every { contentService.getContentList() } returns contentList
+
+        mockMvc.perform(
+            get("/contents")
+                .contentType(MediaType.APPLICATION_JSON)
         )
             .andExpect(status().isOk)
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -38,5 +57,57 @@ class ContentControllerTest {
             .andExpect(jsonPath("$[0].category").value("Software"))
             .andExpect(jsonPath("$[1].id").value(2))
             .andExpect(jsonPath("$[1].category").value("Network"))
+    }
+
+    @Test
+    fun `should create content successfully`() {
+        val createContentDTO = CreateContentDTO(
+            category = "Technology",
+            content = "Kotlin is amazing!",
+            media = "https://example.com/image.png",
+            createdTime = LocalDateTime.now()
+        )
+
+        val readContentDetailDTO = ReadContentDetailDTO(
+            id = 1L,
+            category = createContentDTO.category,
+            content = createContentDTO.content,
+            media = createContentDTO.media,
+            createdTime = LocalDateTime.now()
+        )
+
+        every { contentService.createContent(createContentDTO) } returns readContentDetailDTO
+
+        mockMvc.perform(
+            post("/contents")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(createContentDTO))
+        )
+            .andExpect(status().isOk)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.id").value(1L))
+            .andExpect(jsonPath("$.category").value("Technology"))
+            .andExpect(jsonPath("$.content").value("Kotlin is amazing!"))
+            .andExpect(jsonPath("$.media").value("https://example.com/image.png"))
+    }
+
+    @Test
+    fun `should return bad request when content is invalid`() {
+        val invalidContentDTO = CreateContentDTO(
+            category = "",
+            content = "",
+            media = "",
+            createdTime = LocalDateTime.now()
+        )
+
+        mockMvc.perform(
+            post("/contents")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(invalidContentDTO))
+        )
+            .andExpect(status().isBadRequest)
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.error").exists())
+            .andExpect(jsonPath("$.message").exists())
     }
 }

--- a/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
@@ -67,7 +67,6 @@ class ContentControllerTest {
             media = "https://example.com/image.png",
             createdTime = LocalDateTime.now()
         )
-
         val readContentDetailDTO = ReadContentDetailDTO(
             id = 1L,
             category = createContentDTO.category,
@@ -75,7 +74,6 @@ class ContentControllerTest {
             media = createContentDTO.media,
             createdTime = LocalDateTime.now()
         )
-
         every { contentService.createContent(createContentDTO) } returns readContentDetailDTO
 
         mockMvc.perform(

--- a/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
@@ -1,29 +1,31 @@
 package com.aroundme.content
 
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.InjectMocks
-import org.mockito.Mock
-import org.mockito.kotlin.whenever
-import org.springframework.test.context.junit.jupiter.SpringExtension
+import org.junit.jupiter.api.assertThrows
 import java.time.LocalDateTime
 
-@ExtendWith(SpringExtension::class)
 class ContentServiceTest {
 
-    @Mock
-    private lateinit var contentRepository: ContentRepository
-
-    @InjectMocks
-    private lateinit var contentService: ContentService
+    private val contentRepository: ContentRepository = mockk()
+    private val contentService = ContentService(contentRepository)
 
     @Test
     fun `should return content list`() {
         val contentId = 1L
-        val mockContent = Content(id = 1L, category = "Software", content = "Recent trend", media = "/img/trend.jpg", createdTime = LocalDateTime.now())
+        val mockContent = Content(
+            id = 1L,
+            category = "Software",
+            content = "Recent trend",
+            media = "/img/trend.jpg",
+            createdTime = LocalDateTime.now()
+        )
         val contentList = listOf(mockContent)
-        whenever(contentRepository.findAllBy()).thenReturn(contentList)
+        every { contentRepository.findAllBy() } returns contentList
 
         val content = contentService.getContentList()
 
@@ -31,4 +33,50 @@ class ContentServiceTest {
         assertThat(content[0].id).isEqualTo(contentId)
     }
 
+    @Test
+    fun `should create content successfully`() {
+        val createContentDTO = CreateContentDTO(
+            category = "Technology",
+            content = "Kotlin is a great programming language.",
+            media = "https://example.com/kotlin.png",
+            createdTime = LocalDateTime.now()
+        )
+
+        val currentTime = LocalDateTime.now()
+        val mockContent = Content(
+            id = 1L,
+            category = createContentDTO.category,
+            content = createContentDTO.content,
+            media = createContentDTO.media,
+            createdTime = currentTime
+        )
+
+        every { contentRepository.save(any()) } returns mockContent
+
+        val result = contentService.createContent(createContentDTO)
+
+        assertEquals(createContentDTO.category, result?.category)
+        assertEquals(createContentDTO.content, result?.content)
+        assertEquals(createContentDTO.media, result?.media)
+
+        verify(exactly = 1) { contentRepository.save(any()) }
+    }
+
+    @Test
+    fun `should throw exception when content length exceeds limit`() {
+        val createContentDTO = CreateContentDTO(
+            category = "Technology",
+            content = "A".repeat(501),
+            media = "https://example.com/long_content.png",
+            createdTime = LocalDateTime.now()
+        )
+
+        val exception = assertThrows<IllegalArgumentException> {
+            contentService.createContent(createContentDTO)
+        }
+
+        assertEquals("Content length exceeds the limit of 500 characters", exception.message)
+
+        verify(exactly = 0) { contentRepository.save(any()) }
+    }
 }

--- a/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
@@ -41,7 +41,6 @@ class ContentServiceTest {
             media = "https://example.com/kotlin.png",
             createdTime = LocalDateTime.now()
         )
-
         val currentTime = LocalDateTime.now()
         val mockContent = Content(
             id = 1L,
@@ -50,9 +49,7 @@ class ContentServiceTest {
             media = createContentDTO.media,
             createdTime = currentTime
         )
-
         every { contentRepository.save(any()) } returns mockContent
-
         val result = contentService.createContent(createContentDTO)
 
         assertEquals(createContentDTO.category, result?.category)
@@ -63,20 +60,18 @@ class ContentServiceTest {
     }
 
     @Test
-    fun `should throw exception when content length exceeds limit`() {
+    fun `should throw an exception when content length exceeds limit`() {
         val createContentDTO = CreateContentDTO(
             category = "Technology",
             content = "A".repeat(501),
             media = "https://example.com/long_content.png",
             createdTime = LocalDateTime.now()
         )
-
         val exception = assertThrows<IllegalArgumentException> {
             contentService.createContent(createContentDTO)
         }
 
         assertEquals("Content length exceeds the limit of 500 characters", exception.message)
-
         verify(exactly = 0) { contentRepository.save(any()) }
     }
 }


### PR DESCRIPTION
Provides the ability to enter `content`.

After that, a function to check the details of the content will be created, and a function to modify/delete the content will be added. [LINK](https://docs.google.com/document/d/1ONQ8wvhOP6js0KZBT_rPFWBMUgT8YaCfoA3mkJvpUMs/edit?tab=t.0)

In addition, I changed the test library to `Kotest` and `Mockk` to utilize `Kotlin` DSL during Mocking or Assertion.

- `Kotest` : This is the most used test framework in the Kotlin camp. [LINK](https://kotest.io/docs/framework/framework.html)
- `Mockk`: A kotiln-style Mock framework that allows you to take advantage of a kotiln-style DSL. [LINK](https://mockk.io/#dsl-examples)

In addition, session information has not been added to logging because [Issue#2](https://github.com/tein408/aroundme/issues/2) has not been resolved yet, which will be modified after implementing Content-related APIs first.