### PR TITLE
Add content deletion

### DIFF
--- a/src/main/kotlin/com/aroundme/content/Content.kt
+++ b/src/main/kotlin/com/aroundme/content/Content.kt
@@ -10,10 +10,11 @@ import java.time.LocalDateTime
 data class Content (
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     val contentId: Long? = null,
-    val category: String,
-    val content: String,
-    val media: String,
-    val createdTime: LocalDateTime
+    var category: String,
+    var content: String,
+    var media: String,
+    val createdTime: LocalDateTime,
+    var updatedTime: LocalDateTime
 ) {
     fun toReadContentDTO(): ReadContentDTO {
         return ReadContentDTO(
@@ -21,7 +22,8 @@ data class Content (
             content = content,
             category = category,
             media = media,
-            createdTime = createdTime
+            createdTime = createdTime,
+            updatedTime = updatedTime
         )
     }
 
@@ -31,7 +33,8 @@ data class Content (
             content = content,
             category = category,
             media = media,
-            createdTime = createdTime
+            createdTime = createdTime,
+            updatedTime = updatedTime
         )
     }
 }

--- a/src/main/kotlin/com/aroundme/content/ContentController.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentController.kt
@@ -74,4 +74,17 @@ class ContentController (
             .ok()
             .body(readContentDetailDTO)
     }
+
+    /**
+     * Deletes a content through contentId
+     *
+     * @param contentId
+     * @return ResponseEntity<Void>
+     */
+    @DeleteMapping("/contents/{contentId}")
+    fun deleteContent(@PathVariable contentId: Long): ResponseEntity<Void> {
+        contentService.deleteContent(contentId)
+        return ResponseEntity.noContent().build()
+    }
+
 }

--- a/src/main/kotlin/com/aroundme/content/ContentController.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentController.kt
@@ -59,4 +59,19 @@ class ContentController (
             .ok()
             .body(readContentDetailDTO)
     }
+
+    /**
+     * Updates a content to cover text and media
+     *
+     * @param updateContentDTO
+     * @return content details
+     */
+    @PatchMapping("/contents/{contentId}")
+    fun updateContent(@PathVariable contentId: Long, @RequestBody updateContentDTO: UpdateContentDTO): ResponseEntity<ReadContentDetailDTO> {
+        logger.info("Controller - Updating content by id: $contentId and updated content: $updateContentDTO")
+        val readContentDetailDTO = contentService.updateContent(contentId, updateContentDTO)
+        return ResponseEntity
+            .ok()
+            .body(readContentDetailDTO)
+    }
 }

--- a/src/main/kotlin/com/aroundme/content/ContentDTO.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentDTO.kt
@@ -7,14 +7,16 @@ data class ReadContentDTO (
     val category: String,
     val content: String,
     val media: String,
-    val createdTime: LocalDateTime
+    val createdTime: LocalDateTime,
+    val updatedTime: LocalDateTime
 )
 
 data class CreateContentDTO (
     val category: String,
     val content: String,
     val media: String,
-    val createdTime: LocalDateTime
+    val createdTime: LocalDateTime,
+    val updatedTime: LocalDateTime
 ) {
     fun validate() {
         if (category.isBlank()) throw IllegalArgumentException("Category must not be blank")
@@ -28,5 +30,18 @@ data class ReadContentDetailDTO(
     val category: String,
     val content: String,
     val media: String,
-    val createdTime: LocalDateTime
+    val createdTime: LocalDateTime,
+    val updatedTime: LocalDateTime
 )
+
+data class UpdateContentDTO (
+    val category: String,
+    val content: String,
+    val media: String,
+) {
+    fun validate() {
+        if (category.isBlank()) throw IllegalArgumentException("Category must not be blank")
+        if (content.isBlank()) throw IllegalArgumentException("Content must not be blank")
+        if (media.isBlank()) throw IllegalArgumentException("Media must not be blank")
+    }
+}

--- a/src/main/kotlin/com/aroundme/content/ContentService.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentService.kt
@@ -113,4 +113,19 @@ class ContentService (
         )
     }
 
+    /**
+     * Deletes a content through contentId
+     *
+     * @param contentId
+     * @return void
+     */
+    @Transactional
+    fun deleteContent(contentId: Long) {
+        logger.info("Service - Deleting content by id: $contentId")
+        val content = contentRepository.findByIdOrNull(contentId)
+            ?: throw IllegalArgumentException("Content with id $contentId not found")
+        contentRepository.delete(content)
+        logger.info("Content with id $contentId has been deleted")
+    }
+
 }

--- a/src/main/kotlin/com/aroundme/content/ContentService.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentService.kt
@@ -40,13 +40,14 @@ class ContentService (
         logger.info("Service - Creating new content: $createContentDTO")
         val currentTime = LocalDateTime.now()
 
-        validateContent(createContentDTO)
+        validateContent(createContentDTO.content)
 
         val content = Content(
             category = createContentDTO.category,
             content = createContentDTO.content,
             media = createContentDTO.media,
-            createdTime = currentTime
+            createdTime = currentTime,
+            updatedTime = currentTime
         )
         val savedContent = contentRepository.save(content)
         logger.info { "Service - Content created successfully: $savedContent" }
@@ -56,12 +57,13 @@ class ContentService (
             createContentDTO.category,
             createContentDTO.content,
             createContentDTO.media,
-            currentTime
+            createContentDTO.createdTime,
+            createContentDTO.updatedTime
         )
     }
 
-    private fun validateContent(createContentDTO: CreateContentDTO) {
-        if (createContentDTO.content.length > 500) {
+    private fun validateContent(content: String) {
+        if (content.length > 500) {
             throw IllegalArgumentException("Content length exceeds the limit of 500 characters")
         }
     }
@@ -77,6 +79,38 @@ class ContentService (
         val content = contentRepository.findByIdOrNull(contentId)
             ?: throw IllegalArgumentException("Content with id $contentId not found")
         return content.toReadContentDetailDTO()
+    }
+
+    /**
+     * Updates a content to cover text and media
+     *
+     * @param updateContentDTO
+     * @return content details
+     */
+    @Transactional
+    fun updateContent(contentId: Long, updateContentDTO: UpdateContentDTO): ReadContentDetailDTO {
+        logger.info("Service - Updating content by id: $contentId and updated content: $updateContentDTO")
+
+        updateContentDTO.validate()
+        validateContent(updateContentDTO.content)
+
+        val currentTime = LocalDateTime.now()
+        val findContent = contentRepository.findByIdOrNull(contentId)
+            ?: throw IllegalArgumentException("Content with id $contentId not found")
+
+        updateContentDTO.category.let { findContent.category = it }
+        updateContentDTO.content.let { findContent.content = it }
+        updateContentDTO.media.let { findContent.media = it }
+        findContent.updatedTime = currentTime
+
+        return ReadContentDetailDTO(
+            contentId,
+            updateContentDTO.category,
+            updateContentDTO.content,
+            updateContentDTO.media,
+            findContent.createdTime,
+            findContent.updatedTime
+        )
     }
 
 }

--- a/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
@@ -3,6 +3,7 @@ package com.aroundme.content
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.mockk.every
 import com.ninjasquad.springmockk.MockkBean
+import io.mockk.justRun
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -138,7 +139,7 @@ class ContentControllerTest {
     }
 
     @Test
-    fun `should return 404 when content does not exist`() {
+    fun `should return 404 when updating content does not exist`() {
         val contentId = 99L
         every { contentService.getContentDetail(contentId) } throws IllegalArgumentException("Content with id $contentId not found")
 
@@ -180,4 +181,14 @@ class ContentControllerTest {
             .andExpect(jsonPath("$.media").value("Updated Media"))
             .andExpect(jsonPath("$.updatedTime").exists())
     }
+
+    @Test
+    fun `should delete content successfully`() {
+        val contentId = 1L
+        justRun { contentService.deleteContent(contentId) }
+
+        mockMvc.perform(delete("/contents/{contentId}", contentId))
+            .andExpect(status().isNoContent)
+    }
+
 }

--- a/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
@@ -8,8 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import java.time.LocalDateTime
 
@@ -33,14 +32,16 @@ class ContentControllerTest {
                 category = "Software",
                 content = "John Doe's log",
                 media = "/image.jpg",
-                createdTime = LocalDateTime.now()
+                createdTime = LocalDateTime.now(),
+                updatedTime = LocalDateTime.now()
             ),
             ReadContentDTO(
                 contentId = 2L,
                 category = "Network",
                 content = "Jane Smith's announce",
                 media = "/tech.jpg",
-                createdTime = LocalDateTime.now()
+                createdTime = LocalDateTime.now(),
+                updatedTime = LocalDateTime.now()
             )
         )
 
@@ -65,14 +66,16 @@ class ContentControllerTest {
             category = "Technology",
             content = "Kotlin is amazing!",
             media = "https://example.com/image.png",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         val readContentDetailDTO = ReadContentDetailDTO(
             contentId = 1L,
             category = createContentDTO.category,
             content = createContentDTO.content,
             media = createContentDTO.media,
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         every { contentService.createContent(createContentDTO) } returns readContentDetailDTO
 
@@ -95,7 +98,8 @@ class ContentControllerTest {
             category = "",
             content = "",
             media = "",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
 
         mockMvc.perform(
@@ -117,7 +121,8 @@ class ContentControllerTest {
             category = "Technology",
             content = "Sample content",
             media = "/image.jpg",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         every { contentService.getContentDetail(contentId) } returns readContentDetailDTO
 
@@ -144,5 +149,35 @@ class ContentControllerTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.error").exists())
             .andExpect(jsonPath("$.message").value("Content with id $contentId not found"))
+    }
+
+    @Test
+    fun `should update content successfully`() {
+        val contentId = 1L
+        val updateContentDTO = UpdateContentDTO(
+            category = "Updated Category",
+            content = "Updated Content",
+            media = "Updated Media"
+        )
+        val updatedContent = ReadContentDetailDTO(
+            contentId = contentId,
+            category = "Updated Category",
+            content = "Updated Content",
+            media = "Updated Media",
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
+        )
+        every { contentService.updateContent(contentId, updateContentDTO) } returns updatedContent
+
+        mockMvc.perform(
+            patch("/contents/$contentId")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(updateContentDTO))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.category").value("Updated Category"))
+            .andExpect(jsonPath("$.content").value("Updated Content"))
+            .andExpect(jsonPath("$.media").value("Updated Media"))
+            .andExpect(jsonPath("$.updatedTime").exists())
     }
 }

--- a/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
@@ -1,8 +1,6 @@
 package com.aroundme.content
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.verify
+import io.mockk.*
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -191,4 +189,38 @@ class ContentServiceTest {
 
         assertEquals("Content with id $contentId not found", exception.message)
     }
+
+    @Test
+    fun `should delete a content successfully`() {
+        val contentId = 1L
+        val content = Content(
+            contentId = contentId,
+            category = "Test Category",
+            content = "Test Content",
+            media = "Test Media",
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
+        )
+        every { contentRepository.findByIdOrNull(contentId) } returns content
+        justRun { contentRepository.delete(content) }
+
+        contentService.deleteContent(contentId)
+
+        verify(exactly = 1) { contentRepository.findByIdOrNull(contentId) }
+        verify(exactly = 1) { contentRepository.delete(content) }
+    }
+
+    @Test
+    fun `should throw an exception when deleting content if the content does not exist`() {
+        val contentId = 99L
+        every { contentRepository.findByIdOrNull(contentId) } returns null
+
+        val exception = assertThrows<IllegalArgumentException> {
+            contentService.deleteContent(contentId)
+        }
+        assertEquals("Content with id $contentId not found", exception.message)
+        verify(exactly = 1) { contentRepository.findByIdOrNull(contentId) }
+        verify(exactly = 0) { contentRepository.delete(any()) }
+    }
+
 }

--- a/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
@@ -5,6 +5,7 @@ import io.mockk.mockk
 import io.mockk.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
@@ -23,7 +24,8 @@ class ContentServiceTest {
             category = "Software",
             content = "Recent trend",
             media = "/img/trend.jpg",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         val contentList = listOf(mockContent)
         every { contentRepository.findAllBy() } returns contentList
@@ -40,7 +42,8 @@ class ContentServiceTest {
             category = "Technology",
             content = "Kotlin is a great programming language.",
             media = "https://example.com/kotlin.png",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         val currentTime = LocalDateTime.now()
         val mockContent = Content(
@@ -48,7 +51,8 @@ class ContentServiceTest {
             category = createContentDTO.category,
             content = createContentDTO.content,
             media = createContentDTO.media,
-            createdTime = currentTime
+            createdTime = currentTime,
+            updatedTime = currentTime
         )
         every { contentRepository.save(any()) } returns mockContent
         val result = contentService.createContent(createContentDTO)
@@ -66,7 +70,8 @@ class ContentServiceTest {
             category = "Technology",
             content = "A".repeat(501),
             media = "https://example.com/long_content.png",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         val exception = assertThrows<IllegalArgumentException> {
             contentService.createContent(createContentDTO)
@@ -84,7 +89,8 @@ class ContentServiceTest {
             category = "Technology",
             content = "Sample content",
             media = "/image.jpg",
-            createdTime = LocalDateTime.now()
+            createdTime = LocalDateTime.now(),
+            updatedTime = LocalDateTime.now()
         )
         every { contentRepository.findByIdOrNull(contentId) } returns findContent
 
@@ -104,6 +110,83 @@ class ContentServiceTest {
 
         val exception = assertThrows<IllegalArgumentException> {
             contentService.getContentDetail(contentId)
+        }
+
+        assertEquals("Content with id $contentId not found", exception.message)
+    }
+
+    @Test
+    fun `should update content successfully`() {
+        val contentId = 1L
+        val updateContentDTO = UpdateContentDTO(
+            category = "Updated Category",
+            content = "Updated Content",
+            media = "Updated Media"
+        )
+        val existingContent = Content(
+            contentId = contentId,
+            category = "Old Category",
+            content = "Old Content",
+            media = "Old Media",
+            createdTime = LocalDateTime.now().minusDays(1),
+            updatedTime = LocalDateTime.now().minusDays(1)
+        )
+        val updatedContent = Content(
+            contentId = contentId,
+            category = "Updated Category",
+            content = "Updated Content",
+            media = "Updated Media",
+            createdTime = existingContent.createdTime,
+            updatedTime = LocalDateTime.now()
+        )
+
+        every { contentRepository.findByIdOrNull(contentId) } returns existingContent
+        every { contentRepository.save(any()) } returns updatedContent
+
+        val result = contentService.updateContent(contentId, updateContentDTO)
+        assertEquals("Updated Category", result.category)
+        assertEquals("Updated Content", result.content)
+        assertEquals("Updated Media", result.media)
+        assertNotNull(result.updatedTime)
+    }
+
+    @Test
+    fun `should throw an exception when updating content if the content's text does not exist`() {
+        val contentId = 1L
+        val updateContentDTO = UpdateContentDTO(
+            category = "Updated Category",
+            content = "",
+            media = "Updated Media"
+        )
+        val existingContent = Content(
+            contentId = contentId,
+            category = "Old Category",
+            content = "Old Content",
+            media = "Old Media",
+            createdTime = LocalDateTime.now().minusDays(1),
+            updatedTime = LocalDateTime.now().minusDays(1)
+        )
+        every { contentRepository.findByIdOrNull(contentId) } returns existingContent
+
+        val exception = assertThrows<IllegalArgumentException> {
+            contentService.updateContent(contentId, updateContentDTO)
+        }
+
+        assertEquals("Content must not be blank", exception.message)
+    }
+
+    @Test
+    fun `should throw an exception when updating content if the content does not exist`() {
+        val contentId = 99L
+        val updateContentDTO = UpdateContentDTO(
+            category = "Updated Category",
+            content = "Updated Content",
+            media = "Updated Media"
+        )
+        every { contentRepository.findByIdOrNull(contentId) } returns null
+
+        val exception = assertThrows<IllegalArgumentException> {
+            contentService.updateContent(contentId, updateContentDTO)
         }
 
         assertEquals("Content with id $contentId not found", exception.message)


### PR DESCRIPTION
Adds the ability to delete a content.

After that, I will add search and filtering functions from the content list according to the development order. [LINK](https://docs.google.com/document/d/1ONQ8wvhOP6js0KZBT_rPFWBMUgT8YaCfoA3mkJvpUMs/edit?tab=t.0)

Currently, there is no information about the author, such as which user wrote the content, so the deletion takes place without separate verification.
When adding user-related features, I plan to add author verification logic for content modification and deletion.