### PR TITLE
Support content filter by createTime

### DIFF
--- a/src/main/kotlin/com/aroundme/content/ContentController.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentController.kt
@@ -2,7 +2,13 @@ package com.aroundme.content
 
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.*
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
 
 /**
  * Content controller class
@@ -74,4 +80,20 @@ class ContentController (
             .ok()
             .body(readContentDetailDTO)
     }
+
+    /**
+     * Filters content through startDate and endDate
+     *
+     * @param startDate, endDate
+     * @return content list
+     */
+    @GetMapping("/contents/filter/date")
+    fun filterByCreatedTime(@RequestParam(required = false) startDate: String?, @RequestParam(required = false) endDate: String?): ResponseEntity<List<ReadContentDTO>> {
+        logger.info("Controller - Filter by startDate: $startDate and endDate: $endDate")
+        val contentList = contentService.filterByCreatedTime(startDate, endDate)
+        return ResponseEntity
+            .ok()
+            .body(contentList)
+    }
+
 }

--- a/src/main/kotlin/com/aroundme/content/ContentRepository.kt
+++ b/src/main/kotlin/com/aroundme/content/ContentRepository.kt
@@ -1,7 +1,9 @@
 package com.aroundme.content
 
 import org.springframework.data.repository.CrudRepository
+import java.time.LocalDateTime
 
 interface ContentRepository: CrudRepository<Content, Long> {
     fun findAllBy(): List<Content>
+    fun findAllByCreatedTimeBetween(startDate: LocalDateTime, endDate: LocalDateTime): List<Content>
 }

--- a/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentControllerTest.kt
@@ -11,7 +11,10 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 @WebMvcTest(ContentController::class)
@@ -182,4 +185,111 @@ class ContentControllerTest {
             .andExpect(jsonPath("$.media").value("Updated Media"))
             .andExpect(jsonPath("$.updatedTime").exists())
     }
+
+    @Test
+    fun `should return filtered content list when valid dates are provided`() {
+        val startDate = LocalDate.of(2025, 1, 1)
+        val endDate = LocalDate.of(2025, 1, 10)
+        val mockContentList = listOf(
+            ReadContentDTO(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "/sample.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            ReadContentDTO(
+                contentId = 2L,
+                category = "sample2",
+                content = "Sample feed 2",
+                media = "/sample2.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+
+        every { contentService.filterByCreatedTime(startDate.toString(), endDate.toString()) } returns mockContentList
+
+        mockMvc.perform(get("/contents/filter/date")
+            .queryParam("startDate", startDate.toString())
+            .queryParam("endDate", endDate.toString()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(mockContentList.size))
+            .andExpect(jsonPath("$[0].contentId").value(mockContentList[0].contentId))
+            .andExpect(jsonPath("$[0].content").value(mockContentList[0].content))
+            .andExpect(jsonPath("$[1].contentId").value(mockContentList[1].contentId))
+            .andExpect(jsonPath("$[1].content").value(mockContentList[1].content))
+    }
+
+    @Test
+    fun `should return filtered content list when start date only provided`() {
+        val startDate = LocalDate.of(2025, 1, 1)
+        val mockContentList = listOf(
+            ReadContentDTO(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "/sample.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            ReadContentDTO(
+                contentId = 2L,
+                category = "sample2",
+                content = "Sample feed 2",
+                media = "/sample2.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+
+        every { contentService.filterByCreatedTime(startDate.toString(), "") } returns mockContentList
+
+        mockMvc.perform(get("/contents/filter/date")
+            .queryParam("startDate", startDate.toString())
+            .queryParam("endDate", ""))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(mockContentList.size))
+            .andExpect(jsonPath("$[0].contentId").value(mockContentList[0].contentId))
+            .andExpect(jsonPath("$[0].content").value(mockContentList[0].content))
+            .andExpect(jsonPath("$[1].contentId").value(mockContentList[1].contentId))
+            .andExpect(jsonPath("$[1].content").value(mockContentList[1].content))
+    }
+
+    @Test
+    fun `should return filtered content list when end date only provided`() {
+        val endDate = LocalDate.of(2025, 1, 10)
+        val mockContentList = listOf(
+            ReadContentDTO(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "/sample.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            ReadContentDTO(
+                contentId = 2L,
+                category = "sample2",
+                content = "Sample feed 2",
+                media = "/sample2.jpg",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+
+        every { contentService.filterByCreatedTime("", endDate.toString()) } returns mockContentList
+
+        mockMvc.perform(get("/contents/filter/date")
+            .queryParam("startDate", "")
+            .queryParam("endDate", endDate.toString()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(mockContentList.size))
+            .andExpect(jsonPath("$[0].contentId").value(mockContentList[0].contentId))
+            .andExpect(jsonPath("$[0].content").value(mockContentList[0].content))
+            .andExpect(jsonPath("$[1].contentId").value(mockContentList[1].contentId))
+            .andExpect(jsonPath("$[1].content").value(mockContentList[1].content))
+    }
+
 }

--- a/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/content/ContentServiceTest.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.data.repository.findByIdOrNull
+import java.time.LocalDate
 import java.time.LocalDateTime
 
 class ContentServiceTest {
@@ -191,4 +192,122 @@ class ContentServiceTest {
 
         assertEquals("Content with id $contentId not found", exception.message)
     }
+
+    @Test
+    fun `should filter contents by created time`() {
+        val startDate = LocalDate.of(2025, 1, 1)
+        val endDate = LocalDate.of(2025, 1, 10)
+        val mockContents = listOf(
+            Content(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            Content(
+                contentId = 2L,
+                category = "sample",
+                content = "Sample feed 2",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+        every { contentRepository.findAllByCreatedTimeBetween(any(), any()) } returns mockContents
+
+        val result = contentService.filterByCreatedTime(startDate.toString(), endDate.toString())
+
+        assertEquals(2, result.size)
+        verify { contentRepository.findAllByCreatedTimeBetween(startDate.atStartOfDay(), endDate.atTime(23, 59, 59)) }
+    }
+
+    @Test
+    fun `should filter contents by created time when start date only provided`() {
+        val startDate = LocalDate.of(2025, 1, 1)
+        val mockContents = listOf(
+            Content(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            Content(
+                contentId = 2L,
+                category = "sample",
+                content = "Sample feed 2",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+        every { contentRepository.findAllByCreatedTimeBetween(any(), any()) } returns mockContents
+
+        val result = contentService.filterByCreatedTime(startDate.toString(), null)
+
+        assertEquals(2, result.size)
+        verify { contentRepository.findAllByCreatedTimeBetween(startDate.atStartOfDay(), startDate.atTime(23, 59, 59)) }
+    }
+
+    @Test
+    fun `should filter contents by created time when end date only provided`() {
+        val endDate = LocalDate.of(2025, 1, 10)
+        val mockContents = listOf(
+            Content(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            Content(
+                contentId = 2L,
+                category = "sample",
+                content = "Sample feed 2",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+        every { contentRepository.findAllByCreatedTimeBetween(any(), any()) } returns mockContents
+
+        val result = contentService.filterByCreatedTime(null, endDate.toString())
+
+        assertEquals(2, result.size)
+        verify { contentRepository.findAllByCreatedTimeBetween(endDate.atStartOfDay(), endDate.atTime(23, 59, 59)) }
+    }
+
+    @Test
+    fun `should throw an exception when not valid dates are provided`() {
+        val mockContents = listOf(
+            Content(
+                contentId = 1L,
+                category = "sample",
+                content = "Sample feed 1",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 5, 12, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 5, 12, 0)
+            ),
+            Content(
+                contentId = 2L,
+                category = "sample",
+                content = "Sample feed 2",
+                media = "Test Media",
+                createdTime = LocalDateTime.of(2025, 1, 9, 18, 0),
+                updatedTime = LocalDateTime.of(2025, 1, 9, 18, 0)
+            )
+        )
+        every { contentRepository.findAllByCreatedTimeBetween(any(), any()) } returns mockContents
+
+        val exception = assertThrows<IllegalArgumentException> {
+            contentService.filterByCreatedTime(null, null)
+        }
+
+        assertEquals("At least one of startDate or endDate must be provided", exception.message)
+    }
+
 }


### PR DESCRIPTION
Provides content filtering through a range of creation dates.

It receives the `startDate` and `endDate` to filter by parameters, and if either of them is empty, it is considered the other date to provide filtering.
ex) Enter `startDate` only: recognize `endDate` as same date as `startDate`

The following features add a category filtering function. [LINK](https://docs.google.com/document/d/1ONQ8wvhOP6js0KZBT_rPFWBMUgT8YaCfoA3mkJvpUMs/edit?tab=t.0)