### PR TITLE
Add a function to support decrease a like

### DIFF
--- a/src/main/kotlin/com/aroundme/likes/LikeController.kt
+++ b/src/main/kotlin/com/aroundme/likes/LikeController.kt
@@ -26,7 +26,7 @@ class LikeController (
     @PostMapping("/contents/{contentId}/like")
     fun increaseLikeCount(@PathVariable contentId: Long, @RequestBody userId: Long): ResponseEntity<Void> {
         logger.info("Liking content $contentId $userId")
-        likeService.increaseLikeCount(contentId, userId)
+        likeService.likeContent(contentId, userId)
         return ResponseEntity.noContent().build()
     }
 
@@ -39,7 +39,7 @@ class LikeController (
     @DeleteMapping("/contents/{contentId}/like")
     fun decreaseLikeCount(@PathVariable contentId: Long, @RequestBody userId: Long): ResponseEntity<Void> {
         logger.info("Decrease a like on content $contentId by $userId")
-        likeService.decreaseLikeCount(contentId, userId)
+        likeService.unlikeContent(contentId, userId)
         return ResponseEntity.noContent().build()
     }
 

--- a/src/main/kotlin/com/aroundme/likes/LikeController.kt
+++ b/src/main/kotlin/com/aroundme/likes/LikeController.kt
@@ -2,6 +2,7 @@ package com.aroundme.likes
 
 import mu.KotlinLogging
 import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -17,15 +18,29 @@ class LikeController (
     private val logger = KotlinLogging.logger {}
 
     /**
-     * Increases a like on a content by user
+     * Increases a like count on a content by user
      *
      * @param contentId, userId
      * @return ResponseEntity<Void>
      */
     @PostMapping("/contents/{contentId}/like")
-    fun likeContent(@PathVariable contentId: Long, @RequestBody userId: Long): ResponseEntity<Void> {
+    fun increaseLikeCount(@PathVariable contentId: Long, @RequestBody userId: Long): ResponseEntity<Void> {
         logger.info("Liking content $contentId $userId")
         likeService.increaseLikeCount(contentId, userId)
         return ResponseEntity.noContent().build()
     }
+
+    /**
+     * Decreases a like count on a content by user
+     *
+     * @param contentId, userId
+     * @return ResponseEntity<Void>
+     */
+    @DeleteMapping("/contents/{contentId}/like")
+    fun decreaseLikeCount(@PathVariable contentId: Long, @RequestBody userId: Long): ResponseEntity<Void> {
+        logger.info("Decrease a like on content $contentId by $userId")
+        likeService.decreaseLikeCount(contentId, userId)
+        return ResponseEntity.noContent().build()
+    }
+
 }

--- a/src/main/kotlin/com/aroundme/likes/LikeService.kt
+++ b/src/main/kotlin/com/aroundme/likes/LikeService.kt
@@ -20,7 +20,7 @@ class LikeService (
      */
     @Transactional
     fun increaseLikeCount(contentId: Long, userId: Long) {
-        logger.info("Service - Adding like to $contentId by $userId")
+        logger.info("Service - Increasing a like to $contentId by $userId")
         val currentTime = LocalDateTime.now()
         val likeId = LikesId(contentId, userId)
         val findLikes = likeRepository.findLikesByLikeId(LikesId(contentId, userId))
@@ -35,6 +35,21 @@ class LikeService (
         )
         val savedLikes = likeRepository.save(likes)
         logger.info("Service - Saving like to $contentId by $userId successfully: $savedLikes")
+    }
+
+    /**
+     * Decreases a like count on content by user
+     *
+     * @param contentId, userId
+     * @return void
+     */
+    @Transactional
+    fun decreaseLikeCount(contentId: Long, userId: Long) {
+        logger.info("Service - Decreasing a like to $contentId by $userId")
+        val findLikes = likeRepository.findLikesByLikeId(LikesId(contentId, userId))
+            ?: throw IllegalStateException("User $userId is not liked this content $contentId")
+        likeRepository.delete(findLikes)
+        logger.info("Service - Deleting a like to $contentId by $userId successfully.")
     }
 
 }

--- a/src/main/kotlin/com/aroundme/likes/LikeService.kt
+++ b/src/main/kotlin/com/aroundme/likes/LikeService.kt
@@ -19,7 +19,7 @@ class LikeService (
      * @return void
      */
     @Transactional
-    fun increaseLikeCount(contentId: Long, userId: Long) {
+    fun likeContent(contentId: Long, userId: Long) {
         logger.info("Service - Increasing a like to $contentId by $userId")
         val currentTime = LocalDateTime.now()
         val likeId = LikesId(contentId, userId)
@@ -44,7 +44,7 @@ class LikeService (
      * @return void
      */
     @Transactional
-    fun decreaseLikeCount(contentId: Long, userId: Long) {
+    fun unlikeContent(contentId: Long, userId: Long) {
         logger.info("Service - Decreasing a like to $contentId by $userId")
         val findLikes = likeRepository.findLikesByLikeId(LikesId(contentId, userId))
             ?: throw IllegalStateException("User $userId is not liked this content $contentId")

--- a/src/test/kotlin/com/aroundme/likes/LikeControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeControllerTest.kt
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -33,6 +34,20 @@ class LikeControllerTest {
             post("/contents/$contentId/like")
             .contentType(MediaType.APPLICATION_JSON)
             .content(objectMapper.writeValueAsString(userId))
+        )
+            .andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `should successfully decrease a like count by user`() {
+        val contentId = 1L
+        val userId = 100L
+        justRun {  likeService.decreaseLikeCount(contentId, userId) }
+
+        mockMvc.perform(
+            delete("/contents/$contentId/like")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userId))
         )
             .andExpect(status().isNoContent)
     }

--- a/src/test/kotlin/com/aroundme/likes/LikeControllerTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeControllerTest.kt
@@ -28,7 +28,7 @@ class LikeControllerTest {
         val contentId = 1L
         val userId = 100L
 
-        justRun {  likeService.increaseLikeCount(contentId, userId) }
+        justRun {  likeService.likeContent(contentId, userId) }
 
         mockMvc.perform(
             post("/contents/$contentId/like")
@@ -42,7 +42,7 @@ class LikeControllerTest {
     fun `should successfully decrease a like count by user`() {
         val contentId = 1L
         val userId = 100L
-        justRun {  likeService.decreaseLikeCount(contentId, userId) }
+        justRun {  likeService.unlikeContent(contentId, userId) }
 
         mockMvc.perform(
             delete("/contents/$contentId/like")

--- a/src/test/kotlin/com/aroundme/likes/LikeServiceDatabaseTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeServiceDatabaseTest.kt
@@ -30,7 +30,7 @@ class LikeServiceDatabaseTest {
         val contentId = 1L
         val userId = 100L
 
-        likeService.increaseLikeCount(contentId, userId)
+        likeService.likeContent(contentId, userId)
 
         val savedLike = likeRepository.findById(LikesId(contentId, userId)).orElse(null)
         assertNotNull(savedLike)
@@ -42,10 +42,10 @@ class LikeServiceDatabaseTest {
     fun `should raise an exception when a pair of contentId and userId is already counted for likes`() {
         val contentId = 1L
         val userId = 100L
-        likeService.increaseLikeCount(contentId, userId)
+        likeService.likeContent(contentId, userId)
 
         val exception = assertThrows<IllegalStateException> {
-            likeService.increaseLikeCount(contentId, userId)
+            likeService.likeContent(contentId, userId)
         }
 
         assertEquals("User $userId already liked this content $contentId", exception.message)
@@ -62,7 +62,7 @@ class LikeServiceDatabaseTest {
         val likes = Likes(likeId, LocalDateTime.now())
         likeRepository.save(likes)
 
-        likeService.decreaseLikeCount(contentId, userId)
+        likeService.unlikeContent(contentId, userId)
 
         assertTrue(likeRepository.findById(likeId).isEmpty)
     }
@@ -73,7 +73,7 @@ class LikeServiceDatabaseTest {
         val userId = 100L
 
         val exception = assertThrows<IllegalStateException> {
-            likeService.decreaseLikeCount(contentId, userId)
+            likeService.unlikeContent(contentId, userId)
         }
 
         assertEquals("User $userId is not liked this content $contentId", exception.message)

--- a/src/test/kotlin/com/aroundme/likes/LikeServiceDatabaseTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeServiceDatabaseTest.kt
@@ -2,12 +2,14 @@ package com.aroundme.likes
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.ActiveProfiles
+import java.time.LocalDateTime
 
 @DataJpaTest
 @ActiveProfiles("test")
@@ -50,6 +52,31 @@ class LikeServiceDatabaseTest {
         val findLikes = likeRepository.findById(LikesId(contentId, userId)).orElse(null)
         assertEquals(contentId, findLikes?.likeId?.contentId)
         assertEquals(userId, findLikes?.likeId?.userId)
+    }
+
+    @Test
+    fun `should successfully decrease a like to database`() {
+        val contentId = 1L
+        val userId = 100L
+        val likeId = LikesId(contentId, userId)
+        val likes = Likes(likeId, LocalDateTime.now())
+        likeRepository.save(likes)
+
+        likeService.decreaseLikeCount(contentId, userId)
+
+        assertTrue(likeRepository.findById(likeId).isEmpty)
+    }
+
+    @Test
+    fun `should raise an exception when a pair of contentId and userId not contain like table`() {
+        val contentId = 1L
+        val userId = 100L
+
+        val exception = assertThrows<IllegalStateException> {
+            likeService.decreaseLikeCount(contentId, userId)
+        }
+
+        assertEquals("User $userId is not liked this content $contentId", exception.message)
     }
 
 }

--- a/src/test/kotlin/com/aroundme/likes/LikeServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeServiceTest.kt
@@ -16,7 +16,7 @@ class LikeServiceTest {
     private val likeService = LikeService(likeRepository)
 
     @Test
-    fun `should successfully call increaseLikeCount function when user has not liked before`() {
+    fun `should successfully call likeContent function when user has not liked before`() {
         val contentId = 1L
         val userId = 100L
         val likeId = LikesId(contentId, userId)
@@ -27,7 +27,7 @@ class LikeServiceTest {
         every { likeRepository.findLikesByLikeId(likeId) } returns null
         every { likeRepository.save(any()) } returns mockLikes
 
-        likeService.increaseLikeCount(contentId, userId)
+        likeService.likeContent(contentId, userId)
 
         verify { likeRepository.findLikesByLikeId(likeId) }
         verify { likeRepository.save(any()) }
@@ -45,7 +45,7 @@ class LikeServiceTest {
         every { likeRepository.findLikesByLikeId(likeId) } returns mockLikes
 
         val exception = assertThrows<IllegalStateException> {
-            likeService.increaseLikeCount(contentId, userId)
+            likeService.likeContent(contentId, userId)
         }
 
         assertEquals("User $userId already liked this content $contentId", exception.message)
@@ -62,7 +62,7 @@ class LikeServiceTest {
         every { likeRepository.findLikesByLikeId(likeId) } returns likes
         every { likeRepository.delete(likes) } just Runs
 
-        likeService.decreaseLikeCount(contentId, userId)
+        likeService.unlikeContent(contentId, userId)
 
         verify { likeRepository.findLikesByLikeId(likeId) }
         verify { likeRepository.delete(likes) }
@@ -76,7 +76,7 @@ class LikeServiceTest {
         every { likeRepository.findLikesByLikeId(likeId) } returns null
 
         val exception = assertThrows<IllegalStateException> {
-            likeService.decreaseLikeCount(contentId, userId)
+            likeService.unlikeContent(contentId, userId)
         }
 
         assertEquals("User $userId is not liked this content $contentId", exception.message)

--- a/src/test/kotlin/com/aroundme/likes/LikeServiceTest.kt
+++ b/src/test/kotlin/com/aroundme/likes/LikeServiceTest.kt
@@ -1,6 +1,8 @@
 package com.aroundme.likes
 
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -49,6 +51,37 @@ class LikeServiceTest {
         assertEquals("User $userId already liked this content $contentId", exception.message)
         verify { likeRepository.findLikesByLikeId(likeId) }
         verify(exactly = 0) { likeRepository.save(any()) }
+    }
+
+    @Test
+    fun `should successfully delete function call when user request like deletion`() {
+        val contentId = 1L
+        val userId = 100L
+        val likeId = LikesId(contentId, userId)
+        val likes = Likes(likeId, LocalDateTime.now())
+        every { likeRepository.findLikesByLikeId(likeId) } returns likes
+        every { likeRepository.delete(likes) } just Runs
+
+        likeService.decreaseLikeCount(contentId, userId)
+
+        verify { likeRepository.findLikesByLikeId(likeId) }
+        verify { likeRepository.delete(likes) }
+    }
+
+    @Test
+    fun `should throw an exception when user has not liked the content`() {
+        val contentId = 1L
+        val userId = 100L
+        val likeId = LikesId(contentId, userId)
+        every { likeRepository.findLikesByLikeId(likeId) } returns null
+
+        val exception = assertThrows<IllegalStateException> {
+            likeService.decreaseLikeCount(contentId, userId)
+        }
+
+        assertEquals("User $userId is not liked this content $contentId", exception.message)
+        verify { likeRepository.findLikesByLikeId(likeId) }
+        verify(exactly = 0) { likeRepository.delete(any()) }
     }
 
 }


### PR DESCRIPTION
사용자가 컨텐츠에 대해 '좋아요'를 취소했을 때 '좋아요'를 1 감소시키는 기능을 지원합니다.

다음 기능으로는, 자신이 '좋아요'를 표시한 컨텐츠 목록을 조회하는 기능을 개발합니다. [LINK](https://docs.google.com/document/d/1FY0N9lCoBf_ilQRmlcueapMBCObstSJnqvW9Smc1qFQ/edit?tab=t.0)